### PR TITLE
Data.json Schema

### DIFF
--- a/_datasets/sample-dataset.md
+++ b/_datasets/sample-dataset.md
@@ -1,20 +1,21 @@
 ---
 title: Sample dataset
-notes: This is an example dataset that comes with a new installation of JKAN
-maintainer: Tim Wisniewski
-maintainer_email: tim@timwis.com
-organization: Sample Department
-category: Education
-resources:
-  - url: http://data.phl.opendata.arcgis.com/datasets/1839b35258604422b0b520cbb668df0d_0.csv
-    name: Air Monitoring Stations CSV
-    format: CSV
-    description: Compatible with Excel
-  - url: http://data.phl.opendata.arcgis.com/datasets/1839b35258604422b0b520cbb668df0d_0.zip
-    name: Air Monitoring Stations Shapefile
+publisher:
+  name: Sample Department
+description: This is an example dataset that comes with a new installation of JKAN
+distribution:
+  - title: Air Monitoring Stations CSV
+    downloadURL: 'http://data.phl.opendata.arcgis.com/datasets/1839b35258604422b0b520cbb668df0d_0.csv'
+    format: csv
+  - title: Air Monitoring Stations Shapefile
+    downloadURL: 'http://data.phl.opendata.arcgis.com/datasets/1839b35258604422b0b520cbb668df0d_0.zip'
     format: shp
-  - url: https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/Air_Monitoring_Stations/FeatureServer/0/query
-    name: Air Monitoring Stations GeoService
+  - title: Air Monitoring Stations GeoService
+    downloadURL: 'https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/Air_Monitoring_Stations/FeatureServer/0/query'
     format: api
-    description: Esri Geoservice to interact programmatically with the data
+theme:
+  - Education
+contactPoint:
+  fn: Tim Wisniewski
+  hasEmail: tim@timwis.com
 ---

--- a/_includes/dataset-form-distribution.html
+++ b/_includes/dataset-form-distribution.html
@@ -1,9 +1,9 @@
-<div class="row" data-hook="resource-row">
+<div class="row" data-hook="distribution-row">
   <div class="col-xs-6">
     <label for="distribution[][title]">Resource Name</label>
     <div class="input-group">
       <span class="input-group-btn">
-        <button type="button" class="btn btn-danger" data-hook="remove-resource" title="Remove resource" data-toggle="tooltip"><i class="fa fa-minus"></i></button>
+        <button type="button" class="btn btn-danger" data-hook="remove-distribution" title="Remove resource" data-toggle="tooltip"><i class="fa fa-minus"></i></button>
       </span>
       <input type="text" class="form-control" id="distribution[][title]" name="distribution[][title]" placeholder="Resource Name" value="{{ include.distribution.title }}">
     </div>

--- a/_includes/dataset-form-distribution.html
+++ b/_includes/dataset-form-distribution.html
@@ -1,27 +1,27 @@
 <div class="row" data-hook="resource-row">
   <div class="col-xs-6">
-    <label for="resources[][name]">Resource Name</label>
+    <label for="distribution[][title]">Resource Name</label>
     <div class="input-group">
       <span class="input-group-btn">
         <button type="button" class="btn btn-danger" data-hook="remove-resource" title="Remove resource" data-toggle="tooltip"><i class="fa fa-minus"></i></button>
       </span>
-      <input type="text" class="form-control" id="resources[][name]" name="resources[][name]" placeholder="Resource Name" value="{{ include.resource.name }}">
+      <input type="text" class="form-control" id="distribution[][title]" name="distribution[][title]" placeholder="Resource Name" value="{{ include.distribution.title }}">
     </div>
   </div>
   <div class="col-xs-4">
     <div class="form-group">
-      <label for="resources[][url]">URL</label>
-      <input type="text" class="form-control" id="resources[][url]" name="resources[][url]" placeholder="http://....." value="{{ include.resource.url }}">
+      <label for="distribution[][downloadURL]">URL</label>
+      <input type="text" class="form-control" id="distribution[][downloadURL]" name="distribution[][downloadURL]" placeholder="http://....." value="{{ include.distribution.downloadURL }}">
     </div>
   </div>
   <div class="col-xs-2">
     <div class="form-group">
-      <label for="resources[][format]">Format</label>
-      <select class="form-control" id="resources[][format]" name="resources[][format]">
+      <label for="distribution[][format]">Format</label>
+      <select class="form-control" id="distribution[][format]" name="distribution[][format]">
         <option value="">Select...</option>
         {% assign formats = "api|csv|json|geojson|html|kml|kmz|shp|xml" | split: "|" %}
         {% for format in formats %}
-          {% assign lower_format = include.resource.format | downcase %}
+          {% assign lower_format = include.distribution.format | downcase %}
           <option{% if lower_format == format %} selected="selected"{% endif %}>{{ format }}</option>
         {% endfor %}
       </select>

--- a/_includes/dataset-form.html
+++ b/_includes/dataset-form.html
@@ -22,12 +22,12 @@
 
   <fieldset>
     <h2>Resources</h2>
-    <div data-hook="resource-rows">
+    <div data-hook="distribution-rows">
     {% for distribution in include.dataset.distribution %}
       {% include dataset-form-distribution.html distribution=distribution %}
     {% endfor %}
     </div>
-    <button type="button" class="btn btn-default" data-hook="add-resource" title="Add resource"><i class="fa fa-plus"></i> Resource</button>
+    <button type="button" class="btn btn-default" data-hook="add-distribution" title="Add resource"><i class="fa fa-plus"></i> Resource</button>
   </fieldset>
 
   <fieldset>
@@ -63,6 +63,6 @@
   {% endif %}
 </form>
 
-<script type="text/template" data-hook="tmpl-resource-row">
+<script type="text/template" data-hook="tmpl-distribution-row">
 {% include dataset-form-distribution.html %}
 </script>

--- a/_includes/dataset-form.html
+++ b/_includes/dataset-form.html
@@ -6,25 +6,25 @@
       <input type="text" class="form-control" id="title" name="title" placeholder="Title" value="{{ include.dataset.title }}">
     </div>
     <div class="form-group">
-      <label for="organization">Organization</label>
-      <select class="form-control" id="organization" name="organization">
+      <label for="publisher[name]">Organization</label>
+      <select class="form-control" id="publisher[name]" name="publisher[name]">
         <option value="">Select...</option>
         {% for organization in site.organizations %}
-          <option{% if include.dataset.organization == organization.title %} selected="selected"{% endif %}>{{ organization.title }}</option>
+          <option{% if include.dataset.publisher[name] == organization.title %} selected="selected"{% endif %}>{{ organization.title }}</option>
         {% endfor %}
       </select>
     </div>
     <div class="form-group">
-      <label for="notes">Description</label>
-      <textarea class="form-control" id="notes" placeholder="Description" name="notes">{{ include.dataset.notes }}</textarea>
+      <label for="description">Description</label>
+      <textarea class="form-control" id="description" placeholder="Description" name="description">{{ include.dataset.description }}</textarea>
     </div>
   </fieldset>
 
   <fieldset>
     <h2>Resources</h2>
     <div data-hook="resource-rows">
-    {% for resource in include.dataset.resources %}
-      {% include dataset-form-resource.html resource=resource %}
+    {% for distribution in include.dataset.distribution %}
+      {% include dataset-form-distribution.html distribution=distribution %}
     {% endfor %}
     </div>
     <button type="button" class="btn btn-default" data-hook="add-resource" title="Add resource"><i class="fa fa-plus"></i> Resource</button>
@@ -34,24 +34,24 @@
     <h2>Additional Info</h2>
     
     <div class="form-group">
-      <label for="category[]">Category</label>
-      <select class="form-control select2" id="category[]" name="category[]" multiple="multiple" style="width: 100%">
+      <label for="theme[]">Category</label>
+      <select class="form-control select2" id="theme[]" name="theme[]" multiple="multiple" style="width: 100%">
         {% for category in site.category_list %}
-          <option{% if include.dataset.category == category or include.dataset.category contains category %} selected="selected"{% endif %}>{{ category }}</option>
+          <option{% if include.dataset.theme == category or include.dataset.theme contains category %} selected="selected"{% endif %}>{{ category }}</option>
         {% endfor %}
       </select>
     
     <div class="row">
       <div class="col-xs-6">
         <div class="form-group">
-          <label for="maintainer">Maintainer</label>
-          <input type="text" class="form-control" id="maintainer" name="maintainer" placeholder="Maintainer" value="{{ include.dataset.maintainer }}">
+          <label for="contactPoint[fn]">Maintainer</label>
+          <input type="text" class="form-control" id="contactPoint[fn]" name="contactPoint[fn]" placeholder="Maintainer" value="{{ include.dataset.contactPoint.fn }}">
         </div>
       </div>
       <div class="col-xs-6">
         <div class="form-group">
-          <label for="maintainer_email">Email</label>
-          <input type="text" class="form-control" id="maintainer_email" name="maintainer_email" placeholder="Maintainer Email" value="{{ include.dataset.maintainer_email }}">
+          <label for="contactPoint[hasEmail]">Email</label>
+          <input type="text" class="form-control" id="contactPoint[hasEmail]" name="contactPoint[hasEmail]" placeholder="Maintainer Email" value="{{ include.dataset.contactPoint.hasEmail }}">
         </div>
       </div>
     </div>
@@ -64,5 +64,5 @@
 </form>
 
 <script type="text/template" data-hook="tmpl-resource-row">
-{% include dataset-form-resource.html %}
+{% include dataset-form-distribution.html %}
 </script>

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -11,14 +11,14 @@ layout: default
   There was an error saving this page
 </div>
 
-{% assign organization = site.organizations | where:"title",page.organization | first %}
+{% assign organization = site.organizations | where:"title",page.publisher.name | first %}
 <div class="row" data-hook="read-view">
   {% if organization %}
   <div class="col-sm-3">
     {% if organization.logo %}
-      <a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}" class="thumbnail"><img src="{{ organization.logo }}" alt="{{ organization.title }} logo"></a>
+      <a href="{{ site.baseurl }}/datasets/?organization={{ organization.name | slugify }}" class="thumbnail"><img src="{{ organization.logo }}" alt="{{ organization.name }} logo"></a>
     {% endif %}
-    <h3><a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}">{{ organization.title }}</a></h3>
+    <h3><a href="{{ site.baseurl }}/datasets/?organization={{ organization.name | slugify }}">{{ organization.name }}</a></h3>
     <p>{{ organization.description }}</p>
   </div>
   <div class="col-sm-9">
@@ -29,15 +29,15 @@ layout: default
       {{ page.title }}
       <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.project_title }}/edit/gh-pages/{{ page.path }}" class="pull-right btn btn-default" role="button" data-hook="edit-button">Edit</a>
     </h1>
-    <p>{{ page.notes }}</p>
+    <p>{{ page.description }}</p>
 
     <h2>Resources</h2>
     <ul>
-      {% for resource in page.resources %}
+      {% for distribution in page.distribution %}
       <li>
-        <a href="{{ resource.url }}">{{ resource.name }}</a>
-        {% if resource.format %}({{ resource.format}}){% endif %}
-        {% if resource.description %}<div class="resource-description">{{ resource.description }}</div>{% endif %}
+        <a href="{{ distribution.downloadURL }}">{{ distribution.title }}</a>
+        {% if distribution.format %}({{ distribution.format}}){% endif %}
+        {% if distribution.description %}<div class="resource-description">{{ distribution.description }}</div>{% endif %}
       </li>
       {% endfor %}
     </ul>
@@ -57,14 +57,14 @@ layout: default
       </dd>
       {% endif %}
 
-      {% if page.maintainer != "" %}
+      {% if page.contactPoint.fn != "" %}
       <dt>Maintainer</dt>
-      <dd>{{ page.maintainer }}</dd>
+      <dd>{{ page.contactPoint.fn }}</dd>
       {% endif %}
       
-      {% if page.maintainer_email != "" %}
+      {% if page.contactPoint.hasEmail != "" %}
       <dt>Maintainer Email</dt>
-      <dd>{{ page.maintainer_email }}</dd>
+      <dd>{{ page.contactPoint.hasEmail }}</dd>
       {% endif %}
     </dl>
   </div>

--- a/_organizations/sample-department.md
+++ b/_organizations/sample-department.md
@@ -1,5 +1,5 @@
 ---
-title: Sample Department
+name: Sample Department
 description: This is an example department provided with a new installation of JKAN
 logo: http://i.imgur.com/mrC5xVT.png
 ---

--- a/datasets.json
+++ b/datasets.json
@@ -2,9 +2,11 @@
 ---
 [{% for dataset in site.datasets %}
   {
-    "title": {{ dataset.title | jsonify }},
-    "organization": {{ dataset.publisher.name | jsonify }}{% if dataset.description != "" %},
-    "notes": {{ dataset.description | jsonify }}{% endif %}{% if dataset.category != "" %},
+    "title": {{ dataset.title | jsonify }}{% if dataset.publisher.name %},
+    "publisher": {
+      "name": {{ dataset.publisher.name | jsonify }}
+    }{% endif %}{% if dataset.description != "" %},
+    "description": {{ dataset.description | jsonify }}{% endif %}{% if dataset.category != "" %},
     "category": {{ dataset.category | jsonify }}{% endif %},
     "url": "{{ site.baseurl }}{{ dataset.url }}"
   }{% unless forloop.last %},{% endunless %}{% endfor %}

--- a/datasets.json
+++ b/datasets.json
@@ -3,8 +3,8 @@
 [{% for dataset in site.datasets %}
   {
     "title": {{ dataset.title | jsonify }},
-    "organization": {{ dataset.organization | jsonify }}{% if dataset.notes != "" %},
-    "notes": {{ dataset.notes | jsonify }}{% endif %}{% if dataset.notes != "" %},
+    "organization": {{ dataset.publisher.name | jsonify }}{% if dataset.description != "" %},
+    "notes": {{ dataset.description | jsonify }}{% endif %}{% if dataset.category != "" %},
     "category": {{ dataset.category | jsonify }}{% endif %},
     "url": "{{ site.baseurl }}{{ dataset.url }}"
   }{% unless forloop.last %},{% endunless %}{% endfor %}

--- a/scripts/src/views/add-dataset.js
+++ b/scripts/src/views/add-dataset.js
@@ -9,30 +9,30 @@ export default function (opts) {
   opts || (opts = {})
   const elements = {
     form: queryByHook('dataset-form', opts.el),
-    resourceRows: queryByHook('resource-rows', opts.el),
-    addResourceButton: queryByHook('add-resource', opts.el),
+    distributionRows: queryByHook('distribution-rows', opts.el),
+    adddistributionButton: queryByHook('add-distribution', opts.el),
     alert: queryByHook('alert', opts.el),
     commitUrl: queryByHook('commit-url', opts.el),
     datasetUrl: queryByHook('dataset-url', opts.el),
     select2: $('.select2', opts.el)
   }
 
-  const TmplResourceRow = queryByHook('tmpl-resource-row').html()
+  const TmplDistributionRow = queryByHook('tmpl-distribution-row').html()
 
   // Initialize select2 plugin
   elements.select2.select2()
 
-  // "Remove resource" buttons
-  elements.resourceRows.on('click', '[data-hook~=remove-resource]', (e) => {
+  // "Remove distribution" buttons
+  elements.distributionRows.on('click', '[data-hook~=remove-distribution]', (e) => {
     if (window.confirm('Delete this resource?')) {
-      $(e.currentTarget).closest('[data-hook~=resource-row]').remove()
+      $(e.currentTarget).closest('[data-hook~=distribution-row]').remove()
     }
     e.preventDefault()
   })
 
-  // Add resource button
-  elements.addResourceButton.on('click', function (e) {
-    elements.resourceRows.append(TmplResourceRow)
+  // Add distribution button
+  elements.adddistributionButton.on('click', function (e) {
+    elements.distributionRows.append(TmplDistributionRow)
   })
 
   // Edit form submission

--- a/scripts/src/views/dataset.js
+++ b/scripts/src/views/dataset.js
@@ -11,8 +11,8 @@ export default function (opts) {
     editButton: queryByHook('edit-button', opts.el),
     cancelButton: queryByHook('cancel-button', opts.el),
     deleteButton: queryByHook('delete-button', opts.el),
-    resourceRows: queryByHook('resource-rows', opts.el),
-    addResourceButton: queryByHook('add-resource', opts.el),
+    distributionRows: queryByHook('distribution-rows', opts.el),
+    addDistributionButton: queryByHook('add-distribution', opts.el),
     alert: queryByHook('alert', opts.el),
     commitUrl: queryByHook('commit-url', opts.el),
     readView: queryByHook('read-view', opts.el),
@@ -20,7 +20,7 @@ export default function (opts) {
     select2: $('.select2', opts.el)
   }
 
-  const TmplResourceRow = queryByHook('tmpl-resource-row').html()
+  const TmplDistributionRow = queryByHook('tmpl-distribution-row').html()
 
   // Initialize select2 plugin
   elements.select2.select2()
@@ -31,17 +31,17 @@ export default function (opts) {
     e.preventDefault()
   })
 
-  // "Remove resource" buttons
-  elements.resourceRows.on('click', '[data-hook~=remove-resource]', (e) => {
+  // "Remove distribution" buttons
+  elements.distributionRows.on('click', '[data-hook~=remove-distribution]', (e) => {
     if (window.confirm('Delete this resource?')) {
-      $(e.currentTarget).closest('[data-hook~=resource-row]').remove()
+      $(e.currentTarget).closest('[data-hook~=distribution-row]').remove()
     }
     e.preventDefault()
   })
 
-  // Add resource button
-  elements.addResourceButton.on('click', function (e) {
-    elements.resourceRows.append(TmplResourceRow)
+  // Add distribution button
+  elements.addDistributionButton.on('click', function (e) {
+    elements.distributionRows.append(TmplDistributionRow)
   })
 
   // Edit form submission

--- a/scripts/src/views/datasets.js
+++ b/scripts/src/views/datasets.js
@@ -64,7 +64,8 @@ export default function (opts) {
 // Given an array of datasets, returns an array of their organizations with counts
 function organizationsWithCount (datasets) {
   return chain(datasets)
-    .groupBy('organization')
+    .filter('publisher.name')
+    .groupBy('publisher.name')
     .map(function (datasetsInOrg, organization) {
       const filters = createParamsFilters(pick(params, ['category']))
       const filteredDatasets = filter(datasetsInOrg, filters)


### PR DESCRIPTION
As of this writing, this PR just changes the schema of the current form to data.json. It also changes some of the internal terminology, as it felt like calling things "resources" and "distributions" in the code would decrease readability, so I went with distributions. Rather than changing the template, I figure we'll hold off for a dictionary file to add language support and move the template verbiage there.

Still need to add the other data.json fields to the form/template.

@jjediny what field should we put in each dataset file denoting that it's the "project open data v1.1" schema? Would that be `type: "dcat:Dataset"`? Doesn't seem as descriptive as I'd imagined, and I see the link to project open data is on the catalog itself rather than each dataset. This would just be for backwards compatibility in case we ever need to change schemas and update each dataset file based on this property.

Closes #34 