### PR TITLE
Schema file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ baseurl: /jkan
 github_client_id: 
 gatekeeper_host: 
 
+# Dataset schema
+schema: default
+
 # Categories
 category_list:
   - Arts / Culture / History

--- a/_data/schemas/default.yml
+++ b/_data/schemas/default.yml
@@ -1,0 +1,21 @@
+fields:
+  - field_name: title
+    system_field: title
+    label: Title
+  - field_name: organization
+    system_field: organization
+    label: Organization
+    form_template: form/organization.html
+  - field_name: notes
+    system_field: notes
+    label: Description
+    form_template: form/textarea.html
+  - field_name: category[]
+    system_field: category
+    label: Category
+    form_template: form/category.html
+    display_template: display/category.html
+  - field_name: maintainer
+    label: Maintainer
+  - field_name: maintainer_email
+    label: Maintainer Email

--- a/_data/schemas/pod_v1_1.yml
+++ b/_data/schemas/pod_v1_1.yml
@@ -1,0 +1,21 @@
+fields:
+  - field_name: title
+    system_field: title
+    label: Title
+  - field_name: publisher[name]
+    system_field: organization
+    label: Publisher
+    form_template: form/organization.html
+  - field_name: description
+    system_field: notes
+    label: Description
+    form_template: form/textarea.html
+  - field_name: category[]
+    system_field: category
+    label: Category
+    form_template: form/category.html
+    display_template: display/category.html
+  - field_name: contactPoint[fn]
+    label: Contact Name
+  - field_name: contactPoint[hasEmail]
+    label: Contact Email

--- a/_datasets/sample-dataset.md
+++ b/_datasets/sample-dataset.md
@@ -1,4 +1,5 @@
 ---
+schema: default
 title: Sample dataset
 notes: This is an example dataset that comes with a new installation of JKAN
 maintainer: Tim Wisniewski

--- a/_includes/dataset-form.html
+++ b/_includes/dataset-form.html
@@ -1,7 +1,8 @@
-{% assign fields = site.data.schemas[site.schema].fields %}
+{% assign schema = include.dataset.schema | default: site.schema %}
+{% assign fields = site.data.schemas[schema].fields %}
 {% assign special_fields = "title|organization|notes" | split: "|" %}
 <form data-hook="dataset-form">
-  <input type="hidden" id="schema" name="schema" value="{{ site.schema }}">
+  <input type="hidden" id="schema" name="schema" value="{{ schema }}">
 
   <fieldset>
     {% for field in fields %}

--- a/_includes/dataset-form.html
+++ b/_includes/dataset-form.html
@@ -1,23 +1,18 @@
+{% assign fields = site.data.schemas[site.schema].fields %}
+{% assign special_fields = "title|organization|notes" | split: "|" %}
 <form data-hook="dataset-form">
+  <input type="hidden" id="schema" name="schema" value="{{ site.schema }}">
 
   <fieldset>
-    <div class="form-group">
-      <label for="title">Title</label>
-      <input type="text" class="form-control" id="title" name="title" placeholder="Title" value="{{ include.dataset.title }}">
-    </div>
-    <div class="form-group">
-      <label for="organization">Organization</label>
-      <select class="form-control" id="organization" name="organization">
-        <option value="">Select...</option>
-        {% for organization in site.organizations %}
-          <option{% if include.dataset.organization == organization.title %} selected="selected"{% endif %}>{{ organization.title }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="form-group">
-      <label for="notes">Description</label>
-      <textarea class="form-control" id="notes" placeholder="Description" name="notes">{{ include.dataset.notes }}</textarea>
-    </div>
+    {% for field in fields %}
+      {% if special_fields contains field.system_field %}
+        {% assign template = field.template | default: "form/text.html" %}
+
+        {% include functions/deep-value.html object=include.dataset field_name=field.field_name %}
+
+        {% include {{template}} field=field value=value %}
+      {% endif %}
+    {% endfor %}
   </fieldset>
 
   <fieldset>
@@ -32,29 +27,17 @@
 
   <fieldset>
     <h2>Additional Info</h2>
-    
-    <div class="form-group">
-      <label for="category[]">Category</label>
-      <select class="form-control select2" id="category[]" name="category[]" multiple="multiple" style="width: 100%">
-        {% for category in site.category_list %}
-          <option{% if include.dataset.category == category or include.dataset.category contains category %} selected="selected"{% endif %}>{{ category }}</option>
-        {% endfor %}
-      </select>
-    
-    <div class="row">
-      <div class="col-xs-6">
-        <div class="form-group">
-          <label for="maintainer">Maintainer</label>
-          <input type="text" class="form-control" id="maintainer" name="maintainer" placeholder="Maintainer" value="{{ include.dataset.maintainer }}">
-        </div>
-      </div>
-      <div class="col-xs-6">
-        <div class="form-group">
-          <label for="maintainer_email">Email</label>
-          <input type="text" class="form-control" id="maintainer_email" name="maintainer_email" placeholder="Maintainer Email" value="{{ include.dataset.maintainer_email }}">
-        </div>
-      </div>
-    </div>
+
+    {% for field in fields %}
+      {% unless special_fields contains field.system_field %}
+        {% assign template = field.form_template | default: "form/text.html" %}
+
+        {% include functions/deep-value.html object=include.dataset field_name=field.field_name %}
+
+        {% include {{ template }} field=field value=value %}
+      {% endunless %}
+    {% endfor %}
+
   </fieldset>
 
   <button type="submit" class="btn btn-primary">Submit</button>

--- a/_includes/display/category.html
+++ b/_includes/display/category.html
@@ -1,0 +1,10 @@
+<dt>{{ include.field.label }}</dt>
+<dd>
+  {% if include.value.size %}
+    {% for category in include.value %}
+      <a href="{{ site.baseurl }}/datasets/?category={{ category | slugify }}">{{ category }}</a><br>
+    {% endfor %}
+  {% else %}
+    <a href="{{ site.baseurl }}/datasets/?category={{ include.value | slugify }}">{{ include.value }}</a>
+  {% endif %}
+</dd>

--- a/_includes/form/category.html
+++ b/_includes/form/category.html
@@ -1,0 +1,8 @@
+<div class="form-group">
+  <label for="{{ include.field.field_name }}">{{ include.field.label }}</label>
+  <select class="form-control select2" id="{{ include.field.field_name }}" name="{{ include.field.field_name }}" multiple="multiple" style="width: 100%">
+    {% for category in site.category_list %}
+      <option{% if include.value == category or include.value contains category %} selected="selected"{% endif %}>{{ category }}</option>
+    {% endfor %}
+  </select>
+</div>

--- a/_includes/form/organization.html
+++ b/_includes/form/organization.html
@@ -1,0 +1,9 @@
+<div class="form-group">
+  <label for="{{ include.field.field_name }}">{{ include.field.label }}</label>
+  <select class="form-control" id="{{ include.field.field_name }}" name="{{ include.field.field_name }}">
+    <option value="">{{ include.field.placeholder | default: "Select..." }}</option>
+    {% for organization in site.organizations %}
+      <option{% if include.value == organization.title %} selected="selected"{% endif %}>{{ organization.title }}</option>
+    {% endfor %}
+  </select>
+</div>

--- a/_includes/form/text.html
+++ b/_includes/form/text.html
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <label for="{{ include.field.field_name }}">{{ include.field.label }}</label>
+  <input type="text" class="form-control" id="{{ include.field.field_name }}" name="{{ include.field.field_name }}" placeholder="{{ include.field.placeholder | default include.field.label }}" value="{{ include.value }}">
+</div>

--- a/_includes/form/textarea.html
+++ b/_includes/form/textarea.html
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <label for="{{ include.field.field_name }}">{{ include.field.label }}</label>
+  <textarea class="form-control" id="{{ include.field.field_name }}" placeholder="{{ include.field.placeholder | default: include.field.label }}" name="{{ include.field.field_name }}">{{ include.value }}</textarea>
+</div>

--- a/_includes/functions/deep-value.html
+++ b/_includes/functions/deep-value.html
@@ -1,0 +1,11 @@
+{% comment %}
+  Recursively gets the value of an object using bracket notation
+  ie. allows access to foo[bar][baz]
+  Usage: include functions/deep-value.html object=dataset field_name=foo[bar][baz]
+{% endcomment %}
+
+{% assign value = include.object %}
+{% assign field_layers = include.field_name | remove: "[]" | remove: "]" | split: "[" %}
+{% for layer in field_layers %}
+  {% assign value = value[layer] %}
+{% endfor %}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% include breadcrumbs.html parent="Datasets" %}
-{% assign schema = page.schema | defualt site.schema %}
+{% assign schema = page.schema | default: site.schema %}
 {% assign fields = site.data.schemas[schema].fields %}
 {% assign special_fields = "title|organization|notes" | split: "|" %}
 

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -2,6 +2,21 @@
 layout: default
 ---
 {% include breadcrumbs.html parent="Datasets" %}
+{% assign schema = page.schema | defualt site.schema %}
+{% assign fields = site.data.schemas[schema].fields %}
+{% assign special_fields = "title|organization|notes" | split: "|" %}
+
+{% assign org_field = fields | where: "system_field", "organization" | first %}
+{% include functions/deep-value.html object=page field_name=org_field.field_name %}
+{% assign organization = value %}
+
+{% assign title_field = fields | where: "system_field", "title" | first %}
+{% include functions/deep-value.html object=page field_name=title_field.field_name %}
+{% assign title = value %}
+
+{% assign notes_field = fields | where: "system_field", "notes" | first %}
+{% include functions/deep-value.html object=page field_name=notes_field.field_name %}
+{% assign notes = value %}
 
 <div class="alert alert-success" role="alert" data-hook="alert-success" style="display: none;">
   This dataset has been <a href="#" data-hook="commit-url">saved</a> and the page is currently regenerating.
@@ -11,25 +26,26 @@ layout: default
   There was an error saving this page
 </div>
 
-{% assign organization = site.organizations | where:"title",page.organization | first %}
+
+{% assign org_hash = site.organizations | where: "title", organization | first %}
 <div class="row" data-hook="read-view">
-  {% if organization %}
+  {% if org_hash %}
   <div class="col-sm-3">
-    {% if organization.logo %}
-      <a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}" class="thumbnail"><img src="{{ organization.logo }}" alt="{{ organization.title }} logo"></a>
+    {% if org_hash.logo %}
+      <a href="{{ site.baseurl }}/datasets/?organization={{ org_hash.title | slugify }}" class="thumbnail"><img src="{{ org_hash.logo }}" alt="{{ org_hash.title }} logo"></a>
     {% endif %}
-    <h3><a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}">{{ organization.title }}</a></h3>
-    <p>{{ organization.description }}</p>
+    <h3><a href="{{ site.baseurl }}/datasets/?organization={{ org_hash.title | slugify }}">{{ org_hash.title }}</a></h3>
+    <p>{{ org_hash.description }}</p>
   </div>
   <div class="col-sm-9">
   {% else %}
   <div class="col-sm-12">
   {% endif %}
     <h1>
-      {{ page.title }}
+      {{ title }}
       <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.project_title }}/edit/gh-pages/{{ page.path }}" class="pull-right btn btn-default" role="button" data-hook="edit-button">Edit</a>
     </h1>
-    <p>{{ page.notes }}</p>
+    <p>{{ notes }}</p>
 
     <h2>Resources</h2>
     <ul>
@@ -44,28 +60,19 @@ layout: default
 
     <h2>Additional Info</h2>
     <dl>
-      {% if page.category != "" %}
-      <dt>Category</dt>
-      <dd>
-        {% if page.category.size %}
-          {% for category in page.category %}
-            <a href="{{ site.baseurl }}/datasets/?category={{ category | slugify }}">{{ category }}</a><br>
-          {% endfor %}
-        {% else %}
-          <a href="{{ site.baseurl }}/datasets/?category={{ page.category | slugify }}">{{ page.category }}</a>
-        {% endif %}
-      </dd>
-      {% endif %}
 
-      {% if page.maintainer != "" %}
-      <dt>Maintainer</dt>
-      <dd>{{ page.maintainer }}</dd>
-      {% endif %}
-      
-      {% if page.maintainer_email != "" %}
-      <dt>Maintainer Email</dt>
-      <dd>{{ page.maintainer_email }}</dd>
-      {% endif %}
+      {% for field in fields %}
+        {% unless special_fields contains field.system_field %}
+          {% include functions/deep-value.html object=page field_name=field.field_name %}
+          {% if field.display_template %}
+            {% include {{ field.display_template }} field=field value=value %}
+          {% else %}
+            <dt>{{ field.label }}</dt>
+            <dd>{{ value }}</dd>
+          {% endif %}
+        {% endunless %}
+      {% endfor %}
+
     </dl>
   </div>
 </div>


### PR DESCRIPTION
Following the discussion in pull request #56, which was prompted by issue #34.

This pull request allows the site administrator to add a schema file to the `_data/schemas/` directory and activate it by modifying the `schema` setting in `_config.yml`.

Dataset display pages have (a) title, (b) organization, and (c) description hard-coded into the layout. These are considered "system fields," which schemas should specify using the `system_field` property.

Below that, the _Resources_ are rendered. These need to be configurable too - this pull request isn't quite finished because of this.

Following that, the rest of the fields in the schema file are rendered in the order they are listed in the schema file.

Schema files support bracket notation to access deep values (thanks to a clever/hacky "recursive function" if you can call it that).

Datasets have a `schema` property in them, which allows JKAN to render the display page and form according to the specific dataset (rather than just the site-wide setting).

Thoughts @JJediny?

TODO:
- [ ] Incorporate _Resources_ into the schema files
- [ ] `datasets.json` should access the data via `system_field`
- [ ] Ensure javascript doesn't rely on field names (and uses `data-hook` with system fields instead)