### PR TITLE
Basic Dcat support

### DIFF
--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -17,37 +17,43 @@ layout: default
 </div>
 
 {% assign organization = site.organizations | where:"title",page.organization | first %}
-<div class="row" data-hook="read-view">
+{% capture organization_url %}{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}{% endcapture %}
+
+<div data-hook="read-view" typeof="dcat:Dataset" resource="{{ page.url }}">
   {% if organization %}
-  <div class="col-sm-3">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        {% if organization.logo != "" %}
-        <a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}" class="thumbnail"><img src="{{ organization.logo }}" alt="{{ organization.title }} logo"></a>
-        {% endif %}
+    <div class="col-sm-3" property="dct:publisher" resource="{{ organization_url }}">
+      <div class="panel panel-default">
+          <div class="panel-heading">
+            {% if organization.logo != "" %}
+            <a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}" class="thumbnail"><img src="{{ organization.logo }}" alt="{{ organization.title }} logo"></a>
+            {% endif %}
+          </div>
+          <div class="panel-body">
+            <h3>
+              <a href="{{ organization_url }}" about="{{ organization_url }}" property="foaf:homepage">
+                <span property="foaf:name">{{ organization.title }}</span>
+              </a>
+            </h3>
+            {{ organization.description }}
+          </div>
+        </div>
       </div>
-      <div class="panel-body">
-        <h3><a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}">{{ organization.title }}</a></h3>
-        {{ organization.description }}
-      </div>
-    </div>
-  </div>
   <div class="col-sm-9">
   {% else %}
   <div class="col-sm-12">
   {% endif %}
     <h1>
-      {{ page.title }}
+      <span property="dct:title">{{ page.title }}</span>
       <a href="https://github.com/{{ site.github.owner_name }}/{{ site.github.project_title }}/edit/gh-pages/{{ page.path }}" class="pull-right btn btn-default edit-dataset-btn" role="button" data-hook="edit-button">Edit</a>
     </h1>
-    <p>{{ page.notes }}</p>
+    <p property="dct:description">{{ page.notes }}</p>
 
     <h2>Resources</h2>
     <ul>
       {% for resource in page.resources %}
-      <li data-hook="resource-item">
-        <a href="{{ resource.url }}">{{ resource.name }}</a>
-        {% if resource.format %}<span class="label label-default">{{ resource.format}}</span>{% endif %}
+      <li data-hook="resource-item" property='dcat:distribution' typeof='dcat:Distribution'>
+        <a href="{{ resource.url }}" property='dcat:accessURL'><span property="dct:title">{{ resource.name }}</span></a>
+        {% if resource.format %}<span class="label label-default" property='dcat:mediaType'>{{ resource.format}}</span>{% endif %}
         <a href="#" class="show-resource-details" data-hook="show-resource-details">(Details)</a>
         {% if resource.description %}<div class="resource-description">{{ resource.description }}</div>{% endif %}
         <table class="table table-striped table-condensed resource-details" data-hook="resource-details">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html prefix="dct: http://purl.org/dc/terms/
+              rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+              dcat: http://www.w3.org/ns/dcat#
+              foaf: http://xmlns.com/foaf/0.1/">
 
   {% include head.html %}
 


### PR DESCRIPTION
This PR adds support for the [W3C's Dcat](https://www.w3.org/TR/vocab-dcat/) vocabulary, which is used by [Open Data Certificates](https://certificates.theodi.org/en/) to automatically populate questionnaires. We can currently automatically scrape and award Bronze level certificates to most CKAN repos, so would be great to apply this to JKAN too.

Currently I've added support for [`dct:publisher`](https://www.w3.org/TR/vocab-dcat/#Property:catalog_publisher), [`dct:title`](https://www.w3.org/TR/vocab-dcat/#Property:catalog_title), [`dct:description`](https://www.w3.org/TR/vocab-dcat/#Property:catalog_description) and [`dcat:distribution`](https://www.w3.org/TR/vocab-dcat/#Property:dataset_distribution).

Once support for licenses is added as per #63 (which I'm happy to look at if no one else has already started), we can add [`dct:license`](https://www.w3.org/TR/vocab-dcat/#Property:catalog_license). This should be enough for a dataset to be awarded a bronze level certificate automatically.