### PR TITLE
Updated json gem dependency to 1.8.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.3.1)
       listen (~> 3.0)
-    json (1.8.3)
+    json (1.8.5)
     kramdown (1.9.0)
     liquid (3.0.6)
     listen (3.0.6)


### PR DESCRIPTION
The 1.8.3 json gem isn't compatible with Ruby 2.4, causing an `error: ‘rb_cFixnum’ undeclared (first use in this function)` when doing `bundle install`. 

It's fixed at 1.8.5. Note the current release of the json gem is 2.1, but I figured I'd leave it on the 1.8 branch to avoid any compatibility issues.

Thanks for JKAN - it's awesome!