### PR TITLE
Remove links to tweets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # JKAN [![Build Status](https://travis-ci.org/timwis/jkan.svg?branch=gh-pages)](https://travis-ci.org/timwis/jkan) [![Join the chat at https://gitter.im/timwis/jkan](https://badges.gitter.im/timwis/jkan.svg)](https://gitter.im/timwis/jkan?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 A lightweight, backend-free open data portal, powered by Jekyll
 
-Open-source data portals can be [really](https://twitter.com/waldojaquith/status/282599673569619969).
-[hard](https://twitter.com/chris_whong/status/669207423719235584). to install and maintain. But their
+Open-source data portals can be really hard to install and maintain. But their
 basic purpose of providing links to download data really isn't that complicated. JKAN is a proof-of-concept
 that allows a small, resource-strapped government agency to stand-up an open data portal by simply
 [clicking the fork button](https://help.github.com/articles/fork-a-repo/).


### PR DESCRIPTION
A lot has changed since the tweets linked in the README and home page were made (2012 and 2015), and installing CKAN it is a much more straight-forward experience (although of course it probably takes more time than setting up JKAN). I personally don't think they are needed to support the statement that open data portals can be really hard to install and maintain, or at least the tweets are not fair indicators of the current situation (and they focus on just one alternative).

I'm assuming the home page is rendered from the README but if you are happy with the change and that's not the case please let me know and I'll add any additional files to the PR.