### PR TITLE
Add webrick to Gemfile for Ruby 3.x support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,10 +26,10 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.8.1)
-    faraday (2.6.0)
+    faraday (2.7.2)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.1)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
@@ -204,20 +204,18 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.8.1)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.16.3)
-    nokogiri (1.13.9)
+    minitest (5.17.0)
+    nokogiri (1.14.0)
       mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.9-x64-mingw32)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -225,7 +223,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.6.0)
+    racc (1.6.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -254,8 +252,8 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -264,6 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.1.4
+   2.4.3


### PR DESCRIPTION
Jekyll uses webrick in development mode, and expects it to ship with Ruby. But Ruby 3.0 stopped bundling webrick, which causes an error when you run `jekyll serve` using ruby 3.x. Jekyll 4.3.0—released Oct 2022—adds webrick as a dependency, but GitHub Pages still uses Jekyll 3.9.2 and [has no immediate plans](https://github.com/github/pages-gem/issues/651#issuecomment-1208290235) to upgrade to Jekyll 4. Adding webrick to our Gemfile (per [this thread](https://github.com/jekyll/jekyll/issues/8523)) solves this problem in the meantime.