### PR TITLE
Use progressive enhancement

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,6 +43,8 @@
   {% endif %}
 
   <script>
+  document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/, 'js');
+
   var settings = {
     BASE_URL: {{ site.baseurl | jsonify }} || "",
     PAGE_URL: {{ page.url | jsonify }},

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html prefix="dct: http://purl.org/dc/terms/
+<html class="no-js" prefix="dct: http://purl.org/dc/terms/
               rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
               dcat: http://www.w3.org/ns/dcat#
               foaf: http://xmlns.com/foaf/0.1/">

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 {% include breadcrumbs.html parent="Organizations" %}
+{% assign datasets = site.datasets | where:"organization", page.title %}
+{% assign datasets_count = datasets | size %}
+
 <div class="container">
     <div class="row">
       {% if page.logo and page.logo != empty %}
@@ -18,9 +21,17 @@ layout: default
         </h1>
         <p>{{ page.description }}</p>
         <div data-component="datasets-list" data-organization="{{ page.title | slugify }}">
-          <h3 class="datasets-count" data-hook="datasets-count"></h3>
+          <h3 class="datasets-count" data-hook="datasets-count">{{ datasets_count }}
+              {% if datasets_count == 1 %}dataset{% else %}datasets{% endif %}</h3>
           <input type="text" data-hook="search-query" placeholder="Search..." class="form-control mb-3">
-          <div data-hook="datasets-items"></div>
+          <div data-hook="datasets-items">
+           {% for dataset in datasets %}
+            <dataset>
+              <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
+              {{ dataset.notes }}
+            </dataset>
+           {% endfor %}
+          </div>
         </div>
       </div>
       <div class="view-code-link">

--- a/css/main.css
+++ b/css/main.css
@@ -6,6 +6,10 @@ input[data-hook=search-query] {
   display: block;
 }
 
+.js .js-hidden { display: none; }
+.js-shown { display: none; }
+.js .js-shown { display: block; }
+
 .organization-thumbnail img,
 .category-thumbnail img {
   width: 64px;

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,11 @@
+input[data-hook=search-query] {
+  display: none;
+}
+
+.js input[data-hook=search-query] {
+  display: block;
+}
+
 .organization-thumbnail img,
 .category-thumbnail img {
   width: 64px;

--- a/datasets.html
+++ b/datasets.html
@@ -4,19 +4,49 @@ layout: default
 permalink: /datasets/
 ---
 {% include breadcrumbs.html %}
+{% assign datasets_count = site.datasets | size %}
 
 <div class="row">
   <div class="col-sm-4">
-
     <h3>Categories</h3>
-    <div class="list-group" data-component="categories-filter" data-show="5"></div>
+    <div class="list-group js-shown" data-component="categories-filter" data-show="5"></div>
+    <div class="list-group js-hidden">
+      {% for category in site.dataset_categories %}
+      {% assign count = site.datasets | where: "category", category.name | size %}
+      <a href="{{ site.baseurl }}{{ category.url }}" class="list-group-item">
+        <li class="d-flex justify-content-between align-items-center">
+          {{ category.name }}
+          <span class="badge badge-primary badge-pill">{{ count }}</span>
+        </li>
+      </a>
+      {% endfor %}
+    </div>
 
     <h3>Organizations</h3>
-    <div class="list-group" data-component="organizations-filter" data-show="15"></div>
+    <div class="list-group js-shown" data-component="organizations-filter" data-show="15"></div>
+    <div class="list-group js-hidden">
+      {% for organization in site.organizations %}
+      {% assign count = site.datasets | where: "organization", organization.title | size %}
+      <a href="{{ site.baseurl}}{{ organization.url }}" class="list-group-item">
+        <li class="d-flex justify-content-between align-items-center">
+          {{ organization.title }}
+          <span class="badge badge-primary badge-pill">{{ count }}</span>
+        </li>
+      </a>
+      {% endfor %}
+    </div>
   </div>
   <div class="col-sm-8" data-component="datasets-list">
-    <h3 class="datasets-count" data-hook="datasets-count"></h3>
+    <h3 class="datasets-count" data-hook="datasets-count">{{ datasets_count }}
+      {% if datasets_count == 1 %}dataset{% else %}datasets{% endif %}</h3>
     <input type="text" data-hook="search-query" placeholder="Search..." class="form-control mb-3">
-    <div data-hook="datasets-items"></div>
+    <div data-hook="datasets-items">
+      {% for dataset in site.datasets %}
+      <dataset>
+        <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
+        {{ dataset.notes }}
+      </dataset>
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/datasets.json
+++ b/datasets.json
@@ -4,7 +4,7 @@
   {
     "title": {{ dataset.title | jsonify }},
     "organization": {{ dataset.organization | jsonify }}{% if dataset.notes != "" %},
-    "notes": {{ dataset.notes | jsonify }}{% endif %}{% if dataset.notes != "" %},
+    "notes": {{ dataset.notes | jsonify }}{% endif %}{% if dataset.category != "" %},
     "category": {{ dataset.category | jsonify }}{% endif %},
     "url": "{{ site.baseurl }}{{ dataset.url }}"
   }{% unless forloop.last %},{% endunless %}{% endfor %}


### PR DESCRIPTION
I've pulled in @dracos' commits from #139 on top of the latest `v2` branch, and resolved merge conflicts, but I rewrote the commit that changes `datasets.html`.

Here's how it works this time. With JavaScript disabled:
- It displays _all_ categories and organisations
- Categories and organisations have an accurate count next to them, but they're not sorted by that count (it's not possible without pretty hacky liquid soup)
- It shows all datasets and hides the search input, like in the original PR

With JavaScript enabled, it _hides_ the panels that list all categories and organisations, and populates a separate div. This reduces (but does not eliminate) jitter because the logic to hide it is executed very quickly on page load (swap the `no-js` class for `js` in the `html` element, and CSS takes it from there), whereas the logic to populate and sort the filter panel is done asynchronously after a JSON file is fetched. There still remains a jitter, but it should be _exactly the same_ jitter that you'll already see in JKAN ([demo.jkan.io/datasets](https://demo.jkan.io/datasets)).

We could go even further and add that plugin to sort it, but I reckon this gets us over the line, and we can always revisit the plugin after the GitHub Actions work is complete. What do you think?