### PR TITLE
Use GitHub Actions to deploy to GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
         with:
-          ruby-version: '3.0' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,71 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting this branch
+  push:
+    branches: [gh-pages]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          ruby-version: '3.0' # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Write metadata to a file Jekyll can use
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          echo "branch: $BRANCH" > _config.ci.yml
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" --config _config.ci.yml,_config.yml
+        env:
+          JEKYLL_ENV: production
+          PAGES_REPO_NWO: ${{ github.repository }}
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Per #199, this uses the latest approach to deploying to GitHub Pages (for users who will still prefer to use GitHub Pages over Netlify).

This is based on GitHub's [starter workflow](https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml) for deploying jekyll sites to GitHub Pages

I've got it passing a couple env vars for the github-metadata gem, and the correct branch so that the editor works properly, but the "Edit on GitHub" link is still broken if the fork uses a different default branch from the upstream (an issue with the github-metadata gem).

The main thing I still need to figure out is how to get it to work with user/org pages (instead of repo) pages. For some reason it still gets deployed to `<org-name>.github.io/org-name` instead of just `<org-name>.github.io`.

To test:
1. Fork the jkan repo to your own account (user or org), and make sure to untick the box that says "only copy the gh-pages branch"
2. Go to your repo's settings > Pages > switch Source from "deploy from a branch" to "GitHub Actions"
3. Go to this pull request's branch and modify `.github.workflows/github-pages.yml`, changing the branch on L12 from `gh-pages` to the name of this branch (`github-actions-deploy-pages`)
4. That should automatically kick off a deployment, but if not, go to the Actions page, select this specific action, and there's a button on the right to manually deploy it.

Note that if you want to test editing functionality you'll need to point it to an oauth server [per the readme](https://github.com/timwis/jkan/tree/v2#running-on-github-pages-or-self-hosting).