### PR TITLE
Fix breadcrumbs and org link

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-{% include breadcrumbs.html parent="categories" %}
+{% include breadcrumbs.html parent="Categories" %}
 {% assign datasets = site.datasets | where: "category", page.name %}
 {% assign datasets_count = datasets | size %}
 

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -9,7 +9,7 @@ layout: default
 {% assign resource_system_fields = "name|url|format|description" | split: "|" %}
 
 {% assign organization = site.organizations | where:"title",page.organization | first %}
-{% capture organization_url %}{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}{% endcapture %}
+{% capture organization_url %}{{ site.baseurl }}{{ organization.url }}{% endcapture %}
   <div class="container">
   <div data-component="dataset-display" typeof="dcat:Dataset" resource="{{ page.url }}">
     <div class="row">

--- a/categories.html
+++ b/categories.html
@@ -3,7 +3,7 @@ title: Categories
 layout: default
 permalink: /categories/
 ---
-{% include breadcrumbs.html %}
+{% include breadcrumbs.html parent="Categories" %}
 
 <a href="{{ site.baseurl }}/add-category/" class="btn btn-outline-secondary float-right admin-only" data-hook="add-category-btn"><i class="fa fa-plus"></i> Add category</a>
 

--- a/categories.html
+++ b/categories.html
@@ -3,7 +3,7 @@ title: Categories
 layout: default
 permalink: /categories/
 ---
-{% include breadcrumbs.html parent="Categories" %}
+{% include breadcrumbs.html %}
 
 <a href="{{ site.baseurl }}/add-category/" class="btn btn-outline-secondary float-right admin-only" data-hook="add-category-btn"><i class="fa fa-plus"></i> Add category</a>
 


### PR DESCRIPTION
Tiny enough that I could have just pushed directly to `v2` but thought I'd go via PR for visibility.

- Fixes breadcrumbs on category pages
- Changes the organisation link on a dataset page: instead of linking to the datasets/search page, it links to the actual organisation page.