### PR TITLE
Add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _config.dev.yml
 node_modules
 *.map
 _config.ci.yml
+vendor


### PR DESCRIPTION
Git shouldn't track files in vendor, which holds the project's Ruby gems.

See discussion [here](https://github.com/timwis/jkan/pull/240#issuecomment-1429219999)