### PR TITLE
Fix a few links and remove legacy references

### DIFF
--- a/_data/schemas/default.yml
+++ b/_data/schemas/default.yml
@@ -6,19 +6,15 @@ dataset_fields:
     datajson: title
   - field_name: organization
     label: Organization
-    form_template: form/organization.html
     datajson: publisher.name
   - field_name: notes
     label: Description
-    form_template: form/textarea.html
     datajson: description
   - field_name: license
     label: License
-    form_template: form/license.html
     datajson: license
   - field_name: category
     label: Category
-    form_template: form/category.html
     display_template: display/category.html
     datajson: category
   - field_name: maintainer
@@ -38,7 +34,6 @@ resource_fields:
   - field_name: format
     label: Format
     datajson: distribution.format
-    form_template: form/dropdown.html
     values:
       - api
       - csv
@@ -67,4 +62,3 @@ category_fields:
     label: Logo Credit
   - field_name: featured
     label: Featured on Homepage
-    form_template: form/checkbox.html

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -17,7 +17,7 @@ layout: default
     {% endif %}
       <h1>
         {{ page.name }}
-        <a href="{{ "/editor" | relative_url }}#/collections/categories/entries/{{ page.slug }}" class="float-right btn btn-outline-secondary admin-only">Edit</a>
+        <a href="{{ "/editor" | relative_url }}/#/collections/categories/entries/{{ page.slug }}" class="float-right btn btn-outline-secondary admin-only">Edit</a>
       </h1>
       <p>{{ page.description }}</p>
       <div data-component="datasets-list" data-category="{{ page.name | slugify }}">

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -42,7 +42,7 @@ layout: default
       {% endif %}
         <h1>
           <span property="dct:title">{{ page.title }}</span>
-          <a href="{{ "/editor" | relative_url }}#/collections/dataset/entries/{{ page.slug }}" class="pull-right btn btn-outline-secondary" data-hook="edit-dataset-btn">Edit</a>
+          <a href="{{ "/editor" | relative_url }}/#/collections/datasets/entries/{{ page.slug }}" class="pull-right btn btn-outline-secondary" data-hook="edit-dataset-btn">Edit</a>
         </h1>
         <p property="dct:description" style="text-align: justify; overflow-wrap: break-word;">{{ page.notes }}</p>
 

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -18,7 +18,7 @@ layout: default
           <div class="card mb-3">
             <div class="card-img-top">
               {% if organization.logo and organization.logo != empty %}
-              <a href="{{ site.baseurl }}/datasets/?organization={{ organization.title | slugify }}"><img src="{{ organization.logo | relative_url }}" alt="{{ organization.title }} logo" class="img-thumbnail rounded mx-auto d-block"></a>
+              <a href="{{ organization_url }}"><img src="{{ organization.logo | relative_url }}" alt="{{ organization.title }} logo" class="img-thumbnail rounded mx-auto d-block"></a>
               {% endif %}
                         </div>
                         <div class="card-header">

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -17,7 +17,7 @@ layout: default
       {% endif %}
         <h1>
           {{ page.title }}
-          <a href="{{ "/editor" | relative_url }}#/collections/organization/entries/{{ page.slug }}" class="float-right btn btn-outline-secondary">Edit</a>
+          <a href="{{ "/editor" | relative_url }}/#/collections/organizations/entries/{{ page.slug }}" class="float-right btn btn-outline-secondary">Edit</a>
         </h1>
         <p>{{ page.description }}</p>
         <div data-component="datasets-list" data-organization="{{ page.title | slugify }}">


### PR DESCRIPTION
Per commit messages, this fixes a few edit URLs that must have broken when we added the 'plural' name to the cms config, as well as a couple references I missed in earlier PRs.