### PR TITLE
Remove legacy authentication section from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,10 +7,6 @@ repository: timwis/jkan
 # Site theme
 jkan_theme: Default
 
-# Authentication
-github_client_id: 
-gatekeeper_host: 
-
 # Dataset schema
 schema: default
 


### PR DESCRIPTION
These settings were used to setup gatekeeper in JKAN v1. Just noticed I forgot to remove them from `_config.yml`