### PR TITLE
Fix mobile navbar dropdown functionality

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,7 @@
 <nav class="navbar navbar-expand-sm mb-4 navbar-light bg-light" data-component="navigation">
   <div class="container">
   <a class="navbar-brand" href="{{ site.baseurl }}/">{{ site.title }}</a>
-<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-  <span class="sr-only">Toggle navigation</span>
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
   <span class="navbar-toggler-icon"></span>
 </button>
     <div class="collapse navbar-collapse" id="navbarNavDropdown">


### PR DESCRIPTION
Some of the attributes changed with bootstrap 5, so the navbar dropdown button stopped working on small screens.

Also removed the redundant screen reader label (it's already present in the aria-label attribute and was showing on screens)