### PR TITLE
Markdownify orgs and datasets

### DIFF
--- a/_datasets/opendataphilly.md
+++ b/_datasets/opendataphilly.md
@@ -1,0 +1,21 @@
+---
+schema: default
+title: Open Data Philly
+organization: Sample Department
+notes: "This is a sample dataset showcasing Open Data Phila and the use of markdown. \
+ **Bold** *Italics* ***Both and Italics***  \
+ Contribute to our JKAN instance via [GitHub](https://github.com/azavea/opendataphilly-jkan)."
+
+resources:
+  - name: Main Website
+    url: 'https://opendataphilly.org/'
+    format: html
+  - name: Project Open Data Metadata Schema v1.1 JSON 
+    url: 'https://opendataphilly.org/data.json'
+    format: json
+  - name: JKAN JSON
+    url: 'https://opendataphilly.org/data.json'
+    format: json
+category:
+  - Transportation
+---

--- a/_includes/datasets.html
+++ b/_includes/datasets.html
@@ -1,6 +1,6 @@
 {% for dataset in include.datasets %}
 <dataset>
   <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-  {{ dataset.notes | truncate: 300, '...' }}
+  {{ dataset.notes | markdownify | truncate: 300, '...' }}
 </dataset>
 {% endfor %}

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -17,7 +17,6 @@ layout: default
     {% endif %}
       <h1>
         {{ page.name }}
-        <a href="{{ "/editor" | relative_url }}/#/collections/categories/entries/{{ page.slug }}" class="float-end btn btn-outline-secondary admin-only">Edit</a>
       </h1>
       <p>{{ page.description }}</p>
       <div data-component="datasets-list" data-category="{{ page.name | slugify }}">
@@ -28,7 +27,7 @@ layout: default
           {% for dataset in datasets %}
            <dataset>
              <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-             {{ dataset.notes }}
+             {{ dataset.notes | markdownify }}
              
            </dataset>
           {% endfor %}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -29,7 +29,7 @@ layout: default
                           </h3>
                             </div>
                             <div class="card-body">
-                          {{ organization.description }}
+                          {{ organization.description | markdownify }}
                         </div>
                         <div class="view-code-link">
                           <a href="{{site.github.repository_url}}/blob/main/{{page.path}}?plain=1"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
@@ -44,7 +44,7 @@ layout: default
           <span property="dct:title">{{ page.title }}</span>
           <a href="{{ "/editor" | relative_url }}/#/collections/datasets/entries/{{ page.slug }}" class="pull-right btn btn-outline-secondary" data-hook="edit-dataset-btn">Edit</a>
         </h1>
-        <p property="dct:description" style="text-align: justify; overflow-wrap: break-word;">{{ page.notes }}</p>
+        <p property="dct:description" style="text-align: justify; overflow-wrap: break-word;">{{ page.notes | markdownify }}</p>
 
         <h2>Resources</h2>
         <ul>

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -19,7 +19,7 @@ layout: default
           {{ page.title }}
           <a href="{{ "/editor" | relative_url }}/#/collections/organizations/entries/{{ page.slug }}" class="float-end btn btn-outline-secondary">Edit</a>
         </h1>
-        <p>{{ page.description }}</p>
+        <p>{{ page.description | markdownify }}</p>
         <div data-component="datasets-list" data-organization="{{ page.title | slugify }}">
           <h3 class="datasets-count" data-hook="datasets-count">{{ datasets_count }}
               {% if datasets_count == 1 %}dataset{% else %}datasets{% endif %}</h3>
@@ -28,7 +28,7 @@ layout: default
            {% for dataset in datasets %}
             <dataset>
               <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-              {{ dataset.notes }}
+              {{ dataset.notes | markdownify }}
             </dataset>
            {% endfor %}
           </div>

--- a/_organizations/sample-department.md
+++ b/_organizations/sample-department.md
@@ -1,5 +1,5 @@
 ---
 title: Sample Department
-description: This is an example department provided with a new installation of JKAN
+description: This is ***an*** example department provided with a new installation of JKAN
 logo: https://i.imgur.com/mrC5xVT.png
 ---

--- a/datasets.html
+++ b/datasets.html
@@ -40,7 +40,7 @@ permalink: /datasets/
       {% for dataset in site.datasets %}
       <dataset>
         <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-        {{ dataset.notes }}
+        {{ dataset.notes | markdownify }}
       </dataset>
       {% endfor %}
     </div>

--- a/datasets.json
+++ b/datasets.json
@@ -4,7 +4,7 @@
   {
     "title": {{ dataset.title | jsonify }},
     "organization": {{ dataset.organization | jsonify }}{% if dataset.notes != "" %},
-    "notes": {{ dataset.notes | jsonify }}{% endif %}{% if dataset.category != "" %},
+    "notes": {{ dataset.notes | markdownify | jsonify }}{% endif %}{% if dataset.category != "" %},
     "category": {{ dataset.category | jsonify }}{% endif %},
     "url": "{{ site.baseurl }}{{ dataset.url }}"
   }{% unless forloop.last %},{% endunless %}{% endfor %}

--- a/organizations.html
+++ b/organizations.html
@@ -21,7 +21,7 @@ permalink: /organizations/
         {% endif %}
         <div class="ms-3">
           <h4 style="text-align: start;">{{ organization.title }}</h4>
-          <p style="text-align: justify;">{{ organization.description }}</p>
+          <p style="text-align: justify;">{{ organization.description | markdownify }}</p>
         </div>
       </div>
     </a>


### PR DESCRIPTION
This is mostly just adding markdownify around the notes/descriptions, but also
 * Removes edit/open in GitHub from the categories page
 * Adds a new Sample dataset for OpenDataPhilly.  Figured extra sample files could just be other JKAN instances.  This one test the use of markdown.
 * Added small amount of markdown to default sample org so we can see if it works there.

Resolves: #274