### PR TITLE
Open in Github link should go to code, not preview

### DIFF
--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -32,7 +32,7 @@ layout: default
                           {{ organization.description }}
                         </div>
                         <div class="view-code-link">
-                          <a href="{{site.github.repository_url}}/tree/main/{{page.path}}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
+                          <a href="{{site.github.repository_url}}/blob/main/{{page.path}}?plain=1"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
                         </div>
                       </div>
           </div>


### PR DESCRIPTION
To test, go to a dataset and hit the open in github button. It should take you to the code view instead of the preview, which makes complex yaml look.... bad. See [here](https://github.com/azavea/opendataphilly-jkan/blob/main/_datasets/covid-19-vaccinations.md) for an example.