### PR TITLE
Switch from deprecated nodejs/npm install to just using the version b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM ruby:3.2-bullseye
+FROM ruby:3.2-bookworm
 
-ENV NODE_MAJOR_VERSION 18
-
-RUN curl --silent --show-error --location --retry 5 --retry-connrefuse --retry-delay 4 https://deb.nodesource.com/setup_${NODE_MAJOR_VERSION}.x | bash - \
-  && apt-get update \
-  && apt-get install -y --quiet --no-install-recommends \
-  nodejs
+RUN apt-get update \
+ && apt-get install -y --quiet --no-install-recommends \
+ nodejs npm
 
 ENV GEM_HOME=/usr/gem
 ENV PATH="$GEM_HOME/bin/:$PATH" 


### PR DESCRIPTION
…uilt-in to debian bookwarm

It's nodejs 18.13.0