### PR TITLE
Drop javascript from footer and add to only the pages it's needed on

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,1 @@
-<!-- general behavior -->
-<script type="module" src="{{ site.baseurl }}/scripts/dist/index.js"></script>
-
 <footer></footer>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -5,6 +5,8 @@ layout: default
 {% assign datasets = site.datasets | where: "category", page.name %}
 {% assign datasets_count = datasets | size %}
 
+<script type="module" src="{{ site.baseurl }}/scripts/dist/index.js"></script>
+
 <div class="container">
   <div class="row">
     {% if page.logo and page.logo != empty %}

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -5,6 +5,8 @@ layout: default
 {% assign datasets = site.datasets | where:"organization", page.title %}
 {% assign datasets_count = datasets | size %}
 
+<script type="module" src="{{ site.baseurl }}/scripts/dist/index.js"></script>
+
 <div class="container">
     <div class="row">
       {% if page.logo and page.logo != empty %}

--- a/datasets.html
+++ b/datasets.html
@@ -6,6 +6,8 @@ permalink: /datasets/
 {% include breadcrumbs.html %}
 {% assign datasets_count = site.datasets | size %}
 
+<script type="module" src="{{ site.baseurl }}/scripts/dist/index.js"></script>
+
 <div class="row">
   <div class="col-sm-4">
     <h3>Categories</h3>


### PR DESCRIPTION
The goal is to make it easier to restructure/reduce javascript in the future if we only need to test the 3 pages it acts on.